### PR TITLE
Replace text with chips, link user profile to events and groups

### DIFF
--- a/frontend/src/components/Profile/Profile.js
+++ b/frontend/src/components/Profile/Profile.js
@@ -1,10 +1,77 @@
 import UserInfo from "./UserInfo";
+import {
+  Container,
+  Card,
+  Box,
+  CardContent,
+  List,
+  ListItem,
+  Typography,
+} from "@material-ui/core";
+import UserGroups from "../Groups/UserGroups";
+import { connect } from "react-redux";
+import { useEffect } from "react";
+import { styled } from "@material-ui/styles";
+import Event from "../Events/Event";
+import { getEvents } from "../../actions/events";
 
-function Profile() {
+const SCBox = styled(Box)({
+  display: "flex",
+});
+
+const Box2 = styled(Box)({
+  display: "flex",
+  margin: "64px",
+});
+
+const Box3 = styled(Box)({
+  display: "flex",
+  margin: "80px",
+});
+
+function Profile(props) {
+  const { getEvents } = props;
+
+  useEffect(() => {
+    getEvents();
+  }, [getEvents]);
+
   return (
-    <div className="profile-container">
+    <SCBox>
       <UserInfo />
-    </div>
+      <Box3>
+        <Card>
+          <CardContent>
+            <Typography variant="h6">Your Events</Typography>
+            <List>
+              {props.events.map((event) => (
+                <ListItem key={JSON.stringify(event)}>
+                  <Container>
+                    <Event info={event} />
+                  </Container>
+                </ListItem>
+              ))}
+            </List>
+          </CardContent>
+        </Card>
+      </Box3>
+      <Box2>
+        <UserGroups />
+      </Box2>
+    </SCBox>
   );
 }
-export default Profile;
+
+const mapStateToProps = (state) => {
+  return {
+    events: state.events.events,
+  };
+};
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    getEvents: () => getEvents(dispatch),
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(Profile);

--- a/frontend/src/components/Profile/Profile.js
+++ b/frontend/src/components/Profile/Profile.js
@@ -7,6 +7,7 @@ import {
   List,
   ListItem,
   Typography,
+  Grid,
 } from "@material-ui/core";
 import UserGroups from "../Groups/UserGroups";
 import { connect } from "react-redux";
@@ -14,6 +15,12 @@ import { useEffect } from "react";
 import { styled } from "@material-ui/styles";
 import Event from "../Events/Event";
 import { getEvents } from "../../actions/events";
+import UserEvents from "../Events/UserEvents";
+import { getHomePageData } from "../../actions/user";
+import TmpComponent from "./TmpComponent";
+import { useAuth } from "../../context/AuthContext";
+
+const fromTop = "60px";
 
 const SCBox = styled(Box)({
   display: "flex",
@@ -21,56 +28,57 @@ const SCBox = styled(Box)({
 
 const Box2 = styled(Box)({
   display: "flex",
-  margin: "64px",
+  margin: fromTop,
 });
 
 const Box3 = styled(Box)({
   display: "flex",
-  margin: "80px",
+  marginTop: fromTop,
+  marginLeft: "0px",
 });
 
 function Profile(props) {
-  const { getEvents } = props;
+  const { getHomePageData } = props;
+  const { currentUser } = useAuth();
 
   useEffect(() => {
-    getEvents();
-  }, [getEvents]);
+    getHomePageData(currentUser.uid);
+  }, [getHomePageData, currentUser.uid]);
 
   return (
     <SCBox>
       <UserInfo />
-      <Box3>
-        <Card>
-          <CardContent>
-            <Typography variant="h6">Your Events</Typography>
-            <List>
-              {props.events.map((event) => (
-                <ListItem key={JSON.stringify(event)}>
-                  <Container>
-                    <Event info={event} />
-                  </Container>
-                </ListItem>
-              ))}
-            </List>
-          </CardContent>
-        </Card>
-      </Box3>
-      <Box2>
-        <UserGroups />
-      </Box2>
+      <Grid>
+        <Box3>
+          <TmpComponent
+            title="Your Joined Events"
+            events={props.joinedEvents}
+          />
+          <TmpComponent
+            title="Your Created Events"
+            events={props.createdEvents}
+          />
+        </Box3>
+      </Grid>
+      <Grid>
+        <Box2>
+          <UserGroups />
+        </Box2>
+      </Grid>
     </SCBox>
   );
 }
 
 const mapStateToProps = (state) => {
   return {
-    events: state.events.events,
+    createdEvents: state.user.userEvents.created,
+    joinedEvents: state.user.userEvents.joined,
   };
 };
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    getEvents: () => getEvents(dispatch),
+    getHomePageData: (id) => dispatch(getHomePageData(id)),
   };
 };
 

--- a/frontend/src/components/Profile/TmpComponent.js
+++ b/frontend/src/components/Profile/TmpComponent.js
@@ -1,0 +1,32 @@
+import {
+  Container,
+  Card,
+  Box,
+  CardContent,
+  List,
+  ListItem,
+  Typography,
+  Grid,
+} from "@material-ui/core";
+import Event from "../Events/Event";
+
+function TmpComponent(props) {
+  return (
+    <Card>
+      <CardContent>
+        <Typography variant="h6">{props.title}</Typography>
+        <List>
+          {props.events.map((event) => (
+            <ListItem key={JSON.stringify(event)}>
+              <Container>
+                <Event info={event} />
+              </Container>
+            </ListItem>
+          ))}
+        </List>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default TmpComponent;

--- a/frontend/src/components/Profile/UserInfo.js
+++ b/frontend/src/components/Profile/UserInfo.js
@@ -76,6 +76,17 @@ const SCAvatar = styled(Avatar)({
 
 const SCChip = styled(Chip)({
   marginRight: "10px",
+  marginTop: "10px",
+});
+
+const SCText = styled(Typography)({
+  marginRight: "10px",
+  marginTop: "10px",
+});
+
+const SCButton = styled(Button)({
+  marginTop: "7px",
+  marginLeft: "7px",
 });
 
 const AVATAR_SIZE = 300;
@@ -93,8 +104,11 @@ function UserInfo(props) {
   const { id } = useParams();
   const isOwner = currentUser.uid === id;
 
+  console.log(initialForm);
+
   const handleFormChange = (property) => (event) => {
     console.log("In handleFormChange");
+    console.log({ property, event });
     setForm({
       ...form,
       [property]: event.target.value,
@@ -102,15 +116,11 @@ function UserInfo(props) {
   };
 
   const addTag = (newTag) => {
-    console.log(newTag);
     const newTags = form.tags.concat(newTag);
-    console.log(newTags);
-    console.log(form.tags);
     setForm({
       ...form,
       tags: newTags,
     });
-    console.log(form.tags);
   };
 
   const handleFirstNameChange = handleFormChange("firstName");
@@ -118,6 +128,15 @@ function UserInfo(props) {
   const handleDisplayNameChange = handleFormChange("displayName");
   const handleTagsChange = handleFormChange("tags");
   const handleTagsInputTextChange = handleFormChange("tagsInputText");
+
+  const handleDeleteTag = (tag) => {
+    console.log("In handle delete tag");
+    const newTags = form.tags.filter((item) => item !== tag);
+    setForm({
+      ...form,
+      tags: newTags,
+    });
+  };
 
   const handleEnableEdit = () => {
     setIsEditing(true);
@@ -136,6 +155,7 @@ function UserInfo(props) {
 
   const handleCancel = () => {
     setIsEditing(false);
+    setForm(initialForm);
   };
 
   useEffect(() => {
@@ -260,7 +280,7 @@ function UserInfo(props) {
               onChange={handleDisplayNameChange}
               disabled={!isEditing}
             />
-            <FormControl margin="normal">
+            {/* <FormControl margin="normal">
               <InputLabel variant="outlined" id="tags-checkbox-label">
                 Interested Sports Tags
               </InputLabel>
@@ -272,17 +292,39 @@ function UserInfo(props) {
                 disabled={!isEditing}
                 label="Interested Sports Tags"
                 value={isEditing ? form.tags : initialForm.tags || []}
-                onChange={handleTagsChange}
+                // onChange={handleTagsChange}
                 inputProps={<Input />}
-                renderValue={(selected) =>
-                  TAGS.filter((tag) => selected.includes(tag)).map((item) => {
-                    return isEditing ? (
-                      <SCChip label={item} />
-                    ) : (
-                      <SCChip disabled label={item} />
-                    );
-                  })
-                }
+                renderValue={() => {
+                  return isEditing
+                    ? form.tags.map((item) => {
+                        return isEditing ? (
+                          <SCChip
+                            onDelete={() => handleDeleteTag(item)}
+                            label={item}
+                          />
+                        ) : (
+                          <SCChip
+                            onDelete={() => handleDeleteTag(item)}
+                            disabled
+                            label={item}
+                          />
+                        );
+                      })
+                    : initialForm.tags.map((item) => {
+                        return isEditing ? (
+                          <SCChip
+                            onDelete={() => handleDeleteTag(item)}
+                            label={item}
+                          />
+                        ) : (
+                          <SCChip
+                            onDelete={() => handleDeleteTag(item)}
+                            disabled
+                            label={item}
+                          />
+                        );
+                      });
+                }}
                 MenuProps={{
                   anchorOrigin: {
                     vertical: "bottom",
@@ -308,39 +350,63 @@ function UserInfo(props) {
                   >
                     Add
                   </Button>
-                  {/* <TextField
-                    variant="outlined"
-                    margin="normal"
-                    required
-                    fullWidth
-                    id="firstName"
-                    label="First Name"
-                    name="firstName"
-                    autoFocus
-                    value={
-                      isEditing ? form.firstName : initialForm.firstName || ""
-                    }
-                    onChange={handleFirstNameChange}
-                    disabled={!isEditing}
-                  /> */}
                 </MenuItem>
               </Select>
-            </FormControl>
-            {isEditing && (
-              <Grid container direction="row-reverse" spacing={2}>
-                <Grid item>
-                  <Fab onClick={handleCancel}>
-                    <CloseIcon />
-                  </Fab>
-                </Grid>
-                <Grid item>
-                  <Fab onClick={handleSaveChanges}>
-                    <Check />
-                  </Fab>
-                </Grid>
-              </Grid>
-            )}
+            </FormControl> */}
           </FormControl>
+          <SCText variant="h6">Interested Sports Tags</SCText>
+          {isEditing && (
+            <Grid
+              container
+              direction="column"
+              justifyContent="left"
+              alignItems="left"
+            >
+              <Grid item>
+                <TextField
+                  onChange={handleTagsInputTextChange}
+                  id="outlined-basic"
+                  label="Tag"
+                  // variant="filled"
+                  size="small"
+                  value={form.tagsInputText}
+                />
+                <SCButton
+                  variant="contained"
+                  onClick={() => addTag(form.tagsInputText)}
+                >
+                  Add
+                </SCButton>
+              </Grid>
+            </Grid>
+          )}
+          <Box>
+            {form.tags.map((item) => {
+              return isEditing ? (
+                <SCChip onDelete={() => handleDeleteTag(item)} label={item} />
+              ) : (
+                <SCChip
+                  onDelete={() => handleDeleteTag(item)}
+                  disabled
+                  label={item}
+                />
+              );
+            })}
+          </Box>
+          {isEditing && (
+            <Grid container direction="row-reverse" spacing={2}>
+              <Grid item>
+                <Fab onClick={handleCancel}>
+                  <CloseIcon />
+                </Fab>
+              </Grid>
+              <Grid item>
+                <Fab onClick={handleSaveChanges}>
+                  <Check />
+                </Fab>
+              </Grid>
+            </Grid>
+          )}
         </CardContent>
       </SCCard>
     </SCBox>

--- a/frontend/src/components/Profile/UserInfo.js
+++ b/frontend/src/components/Profile/UserInfo.js
@@ -11,7 +11,6 @@ import {
   InputLabel,
   Select,
   Checkbox,
-  ListItemText,
   Box,
   Typography,
   Button,
@@ -26,7 +25,6 @@ import { TAGS } from "../../tags";
 import CloseIcon from "@material-ui/icons/Close";
 import { connect } from "react-redux";
 import { editUserProfile, getUserProfile } from "../../actions/profile";
-import SportsList from "./SportsList";
 import { useAuth } from "../../context/AuthContext";
 import CloudinaryAvatar from "../shared-components/CloudinaryAvatar";
 

--- a/frontend/src/components/Profile/UserInfo.js
+++ b/frontend/src/components/Profile/UserInfo.js
@@ -23,28 +23,6 @@ import { editUserProfile, getUserProfile } from "../../actions/profile";
 import { useAuth } from "../../context/AuthContext";
 import CloudinaryAvatar from "../shared-components/CloudinaryAvatar";
 
-const useStyles = makeStyles((theme) => ({
-  profile: {
-    "margin-top": "50px",
-    "margin-left": "50px",
-    display: "inline-block",
-  },
-  name: {
-    "margin-left": "50px",
-    "font-style": "Calibri",
-    "margin-bottom": "1px",
-    "padding-bottom": "1px",
-  },
-  email: {
-    "margin-left": "50px",
-    "font-style": "Calibri",
-    "margin-top": "1px",
-    "padding-top": "1px",
-    opacity: 0.75,
-    color: "grey",
-  },
-}));
-
 const SCCard = styled(Card)({
   width: 500,
 });

--- a/frontend/src/components/Profile/UserInfo.js
+++ b/frontend/src/components/Profile/UserInfo.js
@@ -23,6 +23,28 @@ import { editUserProfile, getUserProfile } from "../../actions/profile";
 import { useAuth } from "../../context/AuthContext";
 import CloudinaryAvatar from "../shared-components/CloudinaryAvatar";
 
+const useStyles = makeStyles((theme) => ({
+  profile: {
+    "margin-top": "50px",
+    "margin-left": "50px",
+    display: "inline-block",
+  },
+  name: {
+    "margin-left": "50px",
+    "font-style": "Calibri",
+    "margin-bottom": "1px",
+    "padding-bottom": "1px",
+  },
+  email: {
+    "margin-left": "50px",
+    "font-style": "Calibri",
+    "margin-top": "1px",
+    "padding-top": "1px",
+    opacity: 0.75,
+    color: "grey",
+  },
+}));
+
 const SCCard = styled(Card)({
   width: 500,
 });
@@ -253,79 +275,6 @@ function UserInfo(props) {
               onChange={handleDisplayNameChange}
               disabled={!isEditing}
             />
-            {/* <FormControl margin="normal">
-              <InputLabel variant="outlined" id="tags-checkbox-label">
-                Interested Sports Tags
-              </InputLabel>
-              <Select
-                variant="outlined"
-                labelId="tags-checkbox-label"
-                id="tags-checkbox"
-                multiple
-                disabled={!isEditing}
-                label="Interested Sports Tags"
-                value={isEditing ? form.tags : initialForm.tags || []}
-                // onChange={handleTagsChange}
-                inputProps={<Input />}
-                renderValue={() => {
-                  return isEditing
-                    ? form.tags.map((item) => {
-                        return isEditing ? (
-                          <SCChip
-                            onDelete={() => handleDeleteTag(item)}
-                            label={item}
-                          />
-                        ) : (
-                          <SCChip
-                            onDelete={() => handleDeleteTag(item)}
-                            disabled
-                            label={item}
-                          />
-                        );
-                      })
-                    : initialForm.tags.map((item) => {
-                        return isEditing ? (
-                          <SCChip
-                            onDelete={() => handleDeleteTag(item)}
-                            label={item}
-                          />
-                        ) : (
-                          <SCChip
-                            onDelete={() => handleDeleteTag(item)}
-                            disabled
-                            label={item}
-                          />
-                        );
-                      });
-                }}
-                MenuProps={{
-                  anchorOrigin: {
-                    vertical: "bottom",
-                    horizontal: "left",
-                  },
-                  transformOrigin: {
-                    vertical: "top",
-                    horizontal: "left",
-                  },
-                  getContentAnchorEl: null,
-                }}
-              >
-                <MenuItem>
-                  <TextField
-                    onChange={handleTagsInputTextChange}
-                    id="outlined-basic"
-                    label="Tag"
-                    value={form.tagsInputText}
-                  />
-                  <Button
-                    variant="contained"
-                    onClick={() => addTag(form.tagsInputText)}
-                  >
-                    Add
-                  </Button>
-                </MenuItem>
-              </Select>
-            </FormControl> */}
           </FormControl>
           <SCText variant="h6">Interested Sports Tags</SCText>
           {isEditing && (
@@ -340,7 +289,6 @@ function UserInfo(props) {
                   onChange={handleTagsInputTextChange}
                   id="outlined-basic"
                   label="Tag"
-                  // variant="filled"
                   size="small"
                   value={form.tagsInputText}
                 />

--- a/frontend/src/components/Profile/UserInfo.js
+++ b/frontend/src/components/Profile/UserInfo.js
@@ -34,10 +34,6 @@ const useStyles = makeStyles((theme) => ({
     "margin-left": "50px",
     display: "inline-block",
   },
-  profile_pic: {
-    width: "350px",
-    height: "350px",
-  },
   name: {
     "margin-left": "50px",
     "font-style": "Calibri",
@@ -63,20 +59,26 @@ const SCEditIcon = styled(EditIcon)({
 });
 
 const SCBox = styled(Box)({
-  margin: "80px",
+  margin: "60px",
   display: "flex",
   flexDirection: "column",
   alignItems: "left",
 });
 
+const TextBox = styled(Box)({
+  margin: "30px",
+});
+
 const SCAvatar = styled(Avatar)({
-  height: "400px",
-  width: "400px",
+  height: "100px",
+  width: "100px",
 });
 
 const SCChip = styled(Chip)({
   marginRight: "10px",
 });
+
+const AVATAR_SIZE = 300;
 
 function UserInfo(props) {
   const classes = useStyles();
@@ -92,15 +94,30 @@ function UserInfo(props) {
   const isOwner = currentUser.uid === id;
 
   const handleFormChange = (property) => (event) => {
+    console.log("In handleFormChange");
     setForm({
       ...form,
       [property]: event.target.value,
     });
   };
+
+  const addTag = (newTag) => {
+    console.log(newTag);
+    const newTags = form.tags.concat(newTag);
+    console.log(newTags);
+    console.log(form.tags);
+    setForm({
+      ...form,
+      tags: newTags,
+    });
+    console.log(form.tags);
+  };
+
   const handleFirstNameChange = handleFormChange("firstName");
   const handleLastNameChange = handleFormChange("lastName");
   const handleDisplayNameChange = handleFormChange("displayName");
   const handleTagsChange = handleFormChange("tags");
+  const handleTagsInputTextChange = handleFormChange("tagsInputText");
 
   const handleEnableEdit = () => {
     setIsEditing(true);
@@ -173,10 +190,10 @@ function UserInfo(props) {
                 isEditing ? (
                   <SCAvatar src={previewSource} />
                 ) : (
-                  <CloudinaryAvatar publicId={user.image} size={400} />
+                  <CloudinaryAvatar publicId={user.image} size={AVATAR_SIZE} />
                 )
               ) : (
-                <CloudinaryAvatar publicId={user.image} size={400} />
+                <CloudinaryAvatar publicId={user.image} size={AVATAR_SIZE} />
               )}
             </Grid>
             <Grid item>
@@ -267,15 +284,46 @@ function UserInfo(props) {
                   })
                 }
                 MenuProps={{
+                  anchorOrigin: {
+                    vertical: "bottom",
+                    horizontal: "left",
+                  },
+                  transformOrigin: {
+                    vertical: "top",
+                    horizontal: "left",
+                  },
                   getContentAnchorEl: null,
                 }}
               >
-                {TAGS.map((tag) => (
-                  <MenuItem key={tag} value={tag}>
-                    <Checkbox checked={(form?.tags?.indexOf(tag) || 0) > -1} />
-                    <SCChip label={tag} />
-                  </MenuItem>
-                ))}
+                <MenuItem>
+                  <TextField
+                    onChange={handleTagsInputTextChange}
+                    id="outlined-basic"
+                    label="Tag"
+                    value={form.tagsInputText}
+                  />
+                  <Button
+                    variant="contained"
+                    onClick={() => addTag(form.tagsInputText)}
+                  >
+                    Add
+                  </Button>
+                  {/* <TextField
+                    variant="outlined"
+                    margin="normal"
+                    required
+                    fullWidth
+                    id="firstName"
+                    label="First Name"
+                    name="firstName"
+                    autoFocus
+                    value={
+                      isEditing ? form.firstName : initialForm.firstName || ""
+                    }
+                    onChange={handleFirstNameChange}
+                    disabled={!isEditing}
+                  /> */}
+                </MenuItem>
               </Select>
             </FormControl>
             {isEditing && (

--- a/frontend/src/components/Profile/UserInfo.js
+++ b/frontend/src/components/Profile/UserInfo.js
@@ -286,7 +286,6 @@ function UserInfo(props) {
           </FormControl>
         </CardContent>
       </SCCard>
-      <SportsList />
     </SCBox>
   );
 }

--- a/frontend/src/components/Profile/UserInfo.js
+++ b/frontend/src/components/Profile/UserInfo.js
@@ -7,10 +7,6 @@ import {
   TextField,
   Fab,
   Grid,
-  MenuItem,
-  InputLabel,
-  Select,
-  Checkbox,
   Box,
   Typography,
   Button,
@@ -20,8 +16,7 @@ import EditIcon from "@material-ui/icons/Edit";
 import { useEffect, useState } from "react";
 import { styled } from "@material-ui/styles";
 import { useParams } from "react-router";
-import { Check, Input } from "@material-ui/icons";
-import { TAGS } from "../../tags";
+import { Check } from "@material-ui/icons";
 import CloseIcon from "@material-ui/icons/Close";
 import { connect } from "react-redux";
 import { editUserProfile, getUserProfile } from "../../actions/profile";

--- a/frontend/src/components/Profile/UserInfo.js
+++ b/frontend/src/components/Profile/UserInfo.js
@@ -15,6 +15,7 @@ import {
   Box,
   Typography,
   Button,
+  Chip,
 } from "@material-ui/core";
 import EditIcon from "@material-ui/icons/Edit";
 import { useEffect, useState } from "react";
@@ -64,7 +65,7 @@ const SCEditIcon = styled(EditIcon)({
 });
 
 const SCBox = styled(Box)({
-  marginTop: "80px",
+  margin: "80px",
   display: "flex",
   flexDirection: "column",
   alignItems: "center",
@@ -73,6 +74,10 @@ const SCBox = styled(Box)({
 const SCAvatar = styled(Avatar)({
   height: "400px",
   width: "400px",
+});
+
+const SCChip = styled(Chip)({
+  marginRight: "10px",
 });
 
 function UserInfo(props) {
@@ -255,7 +260,13 @@ function UserInfo(props) {
                 onChange={handleTagsChange}
                 inputProps={<Input />}
                 renderValue={(selected) =>
-                  TAGS.filter((tag) => selected.includes(tag)).join(", ")
+                  TAGS.filter((tag) => selected.includes(tag)).map((item) => {
+                    return isEditing ? (
+                      <SCChip label={item} />
+                    ) : (
+                      <SCChip disabled label={item} />
+                    );
+                  })
                 }
                 MenuProps={{
                   getContentAnchorEl: null,
@@ -264,7 +275,7 @@ function UserInfo(props) {
                 {TAGS.map((tag) => (
                   <MenuItem key={tag} value={tag}>
                     <Checkbox checked={(form?.tags?.indexOf(tag) || 0) > -1} />
-                    <ListItemText primary={tag} />
+                    <SCChip label={tag} />
                   </MenuItem>
                 ))}
               </Select>

--- a/frontend/src/components/Profile/UserInfo.js
+++ b/frontend/src/components/Profile/UserInfo.js
@@ -66,7 +66,7 @@ const SCBox = styled(Box)({
   margin: "80px",
   display: "flex",
   flexDirection: "column",
-  alignItems: "center",
+  alignItems: "left",
 });
 
 const SCAvatar = styled(Avatar)({


### PR DESCRIPTION
View of user info.
![image](https://user-images.githubusercontent.com/40711695/129010786-2b5e38bc-4b8f-49fb-8709-b63c7c6e31a5.png)

New interested sports tags section. 
![image](https://user-images.githubusercontent.com/40711695/129011151-3a0cefaa-7ba9-41ea-a758-b2d38f6ac5b2.png)
Old desired one. This one was not viable if we wanted to have delete buttons because the chips are in a select, and you're not allowed to have interactive content nested inside interactive content. It's not valid HTML.
![image](https://user-images.githubusercontent.com/40711695/128654543-c4bcbb26-5692-4225-9512-52ee4529bd63.png)

View of interested sports tags section when editing the form. Can now easily add and delete arbitrary tags. 
![image](https://user-images.githubusercontent.com/40711695/129010895-d4e642e9-e721-44d5-8e7f-309021bf8ff5.png)



Added events and groups components. 
![image](https://user-images.githubusercontent.com/40711695/129010573-003bbc64-5bcb-45cb-81e2-dbea5583b565.png)


